### PR TITLE
Added Plugin Version

### DIFF
--- a/purplecoat.js
+++ b/purplecoat.js
@@ -1,4 +1,4 @@
-$(function () {
+$(function ($) {
 
   var styles = '.purplecoat { display: none; position: absolute; padding: 5px; box-sizing: border-box; background-color: rgba(142, 68, 173, 0.9); color: #FFF; text-align: center; font-weight: bold; overflow: hidden; z-index: 9999; } .purplecoat-inner { display: table; width: 100%; height: 100%; } .purplecoat-inner-text { display: table-cell; vertical-align: middle;}';
 
@@ -6,51 +6,65 @@ $(function () {
   $style.html(styles);
   $('head').prepend($style);
 
+  var purplecoat = function(target){
+    var purplecoatToggleData = target.data('purplecoat-toggle');
+    var $purplecoatVisible = $("[data-purplecoat-for=" + purplecoatToggleData + "]:visible");
+    var $purplecoatHidden = $("[data-purplecoat-for=" + purplecoatToggleData + "]:hidden");
+
+    if ($purplecoatVisible.size()) {
+      $purplecoatVisible.fadeOut();
+    } else if ($purplecoatHidden.size()) {
+      $purplecoatHidden.fadeIn();
+    } else {
+
+      var purplecoatColorData = target.data('purplecoat-color');
+
+      $("[data-purplecoat=" + purplecoatToggleData + "]").each(function () {
+        var $myself = $(this);
+
+        if ($myself.is(":hidden")) {
+          return;
+        }
+
+        var $purplecoat = $('<div class="purplecoat"></div>');
+        $('body').append($purplecoat);
+
+        var $purplecoatInner = $('<div class="purplecoat-inner"></div>');
+        $purplecoat.append($purplecoatInner);
+
+        var $purplecoatInnerText = $('<div class="purplecoat-inner-text"></div>');
+        $purplecoatInnerText.html($myself.data('purplecoat-label'));
+        $purplecoatInner.append($purplecoatInnerText);
+
+        if (purplecoatColorData) {
+          $purplecoat.css('background-color', purplecoatColorData);
+        }
+
+        $purplecoat
+          .attr('data-purplecoat-for', purplecoatToggleData)
+          .css({
+            'top': $myself.offset().top,
+            'left': $myself.offset().left,
+            'width': $myself.width(),
+            'height': $myself.height() })
+          .fadeIn();
+
+      });
+    }
+
+  }
+
+  $.fn.purplecoat = function(options){
+    var options = $.extend({
+      // color: rgba(63, 159, 252, 0.8)
+    }, options);
+
+    return this.each(function(){
+
+    });
+  }
+
   $('[data-purplecoat-toggle]').on('click', function () {
-
-      var purplecoatToggleData = $(this).data('purplecoat-toggle');
-      var $purplecoatVisible = $("[data-purplecoat-for=" + purplecoatToggleData + "]:visible");
-      var $purplecoatHidden = $("[data-purplecoat-for=" + purplecoatToggleData + "]:hidden");
-
-      if ($purplecoatVisible.size()) {
-        $purplecoatVisible.fadeOut();
-      } else if ($purplecoatHidden.size()) {
-        $purplecoatHidden.fadeIn();
-      } else {
-
-        var purplecoatColorData = $(this).data('purplecoat-color');
-
-        $("[data-purplecoat=" + purplecoatToggleData + "]").each(function () {
-          var $myself = $(this);
-
-          if ($myself.is(":hidden")) {
-            return;
-          }
-
-          var $purplecoat = $('<div class="purplecoat"></div>');
-          $('body').append($purplecoat);
-
-          var $purplecoatInner = $('<div class="purplecoat-inner"></div>');
-          $purplecoat.append($purplecoatInner);
-
-          var $purplecoatInnerText = $('<div class="purplecoat-inner-text"></div>');
-          $purplecoatInnerText.html($myself.data('purplecoat-label'));
-          $purplecoatInner.append($purplecoatInnerText);
-
-          if (purplecoatColorData) {
-            $purplecoat.css('background-color', purplecoatColorData);
-          }
-
-          $purplecoat
-            .attr('data-purplecoat-for', purplecoatToggleData)
-            .css({
-              'top': $myself.offset().top,
-              'left': $myself.offset().left,
-              'width': $myself.width(),
-              'height': $myself.height() })
-            .fadeIn();
-
-        });
-      }
+    purplecoat($(this));
   });
-});
+})(jQuery);

--- a/purplecoat.js
+++ b/purplecoat.js
@@ -6,6 +6,30 @@ $(function ($) {
   $style.html(styles);
   $('head').prepend($style);
 
+  var createOverlay = function(element, elementData, label, color){
+    var $purplecoat = $('<div class="purplecoat"></div>');
+    var $purplecoatInner = $('<div class="purplecoat-inner"></div>');
+    var $purplecoatInnerText = $('<div class="purplecoat-inner-text"></div>');
+
+    $('body').append($purplecoat);
+    $purplecoat.append($purplecoatInner);
+    $purplecoatInnerText.html(label);
+    $purplecoatInner.append($purplecoatInnerText);
+
+    if (color) {
+      $purplecoat.css('background-color', color);
+    }
+
+    $purplecoat
+      .attr('data-purplecoat-for', elementData)
+      .css({
+        'top': element.offset().top,
+        'left': element.offset().left,
+        'width': element.width(),
+        'height': element.height() })
+      .fadeIn();
+  }
+
   var purplecoat = function(target){
     var purplecoatToggleData = target.data('purplecoat-toggle');
     var $purplecoatVisible = $("[data-purplecoat-for=" + purplecoatToggleData + "]:visible");
@@ -26,28 +50,7 @@ $(function ($) {
           return;
         }
 
-        var $purplecoat = $('<div class="purplecoat"></div>');
-        $('body').append($purplecoat);
-
-        var $purplecoatInner = $('<div class="purplecoat-inner"></div>');
-        $purplecoat.append($purplecoatInner);
-
-        var $purplecoatInnerText = $('<div class="purplecoat-inner-text"></div>');
-        $purplecoatInnerText.html($myself.data('purplecoat-label'));
-        $purplecoatInner.append($purplecoatInnerText);
-
-        if (purplecoatColorData) {
-          $purplecoat.css('background-color', purplecoatColorData);
-        }
-
-        $purplecoat
-          .attr('data-purplecoat-for', purplecoatToggleData)
-          .css({
-            'top': $myself.offset().top,
-            'left': $myself.offset().left,
-            'width': $myself.width(),
-            'height': $myself.height() })
-          .fadeIn();
+        createOverlay($myself, purplecoatToggleData, $myself.data('purplecoat-label'), purplecoatColorData);
 
       });
     }
@@ -55,11 +58,31 @@ $(function ($) {
   }
 
   $.fn.purplecoat = function(options){
-    var options = $.extend({
-      // color: rgba(63, 159, 252, 0.8)
+    var self = this;
+    var options = typeof options === "boolean" ? {hide: true, data: self.selector} : $.extend({
+      color: "#EF0038",
+      label: "PurpleCoat",
+      data: self.selector,
+      hide: false
     }, options);
 
+    if(options.hide){
+      $("[data-purplecoat-for=" + options.data + "]:visible").fadeOut({
+        complete: function(){
+          $(this).remove();
+        }
+      });
+      return this;
+    }
+
     return this.each(function(){
+      var $myself = $(this);
+
+      if ($myself.is(":hidden")) {
+        return;
+      }
+
+      createOverlay($myself, options.data, options.label, options.color);
 
     });
   }


### PR DESCRIPTION
Usage:

Adds Purple Coat to every img tag.
$(“img”).purplecoat();

Adds Purple Coat to every img tag with options.
$(“img”).purplecoat({
color: "#EF0038",
label: "PurpleCoat",
hide: false
});

Hides Purplecoat over every img tag.
$(“img”).purplecoat(true);
