### PR TITLE
Set margin of overlay to padding of element

### DIFF
--- a/purplecoat.js
+++ b/purplecoat.js
@@ -44,6 +44,7 @@ $(function () {
           $purplecoat
             .attr('data-purplecoat-for', purplecoatToggleData)
             .css({
+              'margin': $myself.css('padding'),
               'top': $myself.offset().top,
               'left': $myself.offset().left,
               'width': $myself.width(),


### PR DESCRIPTION
I ran into an issue where I was using a large padding and the overlay was not covering exactly what I wanted. So by setting the margin of the overlay to the elements padding it fixed the issue.

![screen shot 2014-11-12 at 9 54 34 am](https://cloud.githubusercontent.com/assets/483829/5012170/fcaa5944-6a51-11e4-8134-f0c1437d0d1b.png)
